### PR TITLE
Added paddings for tables with the 'round' style

### DIFF
--- a/tableprint/style.py
+++ b/tableprint/style.py
@@ -29,10 +29,10 @@ STYLES = {
         row=LineStyle(' ', '', ' ', ' '),
     ),
     'round': TableStyle(
-        top=LineStyle('╭', '─', '┬', '╮'),
-        below_header=LineStyle('├', '─', '┼', '┤'),
-        bottom=LineStyle('╰', '─', '┴', '╯'),
-        row=LineStyle('│', '', '│', '│'),
+        top=LineStyle('╭─', '─', '─┬─', '─╮'),
+        below_header=LineStyle('├─', '─', '─┼─', '─┤'),
+        bottom=LineStyle('╰─', '─', '─┴─', '─╯'),
+        row=LineStyle('│ ', '', ' │ ', ' │'),
     ),
     'banner': TableStyle(
         top=LineStyle('╒', '═', '╤', '╕'),

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -8,7 +8,7 @@ def test_borders():
     """Tests printing of the top and bottom borders"""
 
     # top
-    assert top(5, width=2, style='round') == '╭──┬──┬──┬──┬──╮'
+    assert top(5, width=2, style='round') == '╭────┬────┬────┬────┬────╮'
     assert top(1, width=6, style='grid') == '+------+'
 
     # bottom
@@ -20,7 +20,7 @@ def test_row():
     """Tests printing of a single row of data"""
 
     # valid
-    assert row("abc", width=3, style='round') == '│  a│  b│  c│'
+    assert row("abc", width=3, style='round') == '│   a │   b │   c │'
     assert row([1, 2, 3], width=3, style='clean') == '   1   2   3 '
 
     # invalid

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -11,14 +11,14 @@ def test_context():
     with TableContext('ABC', style='round', width=5, out=output) as t:
         t([1, 2, 3])
         t([4, 5, 6])
-    assert output.getvalue() == '╭─────┬─────┬─────╮\n│  A  │  B  │  C  │\n├─────┼─────┼─────┤\n│    1│    2│    3│\n│    4│    5│    6│\n╰─────┴─────┴─────╯\n'
+    assert output.getvalue() == '╭───────┬───────┬───────╮\n│   A   │   B   │   C   │\n├───────┼───────┼───────┤\n│     1 │     2 │     3 │\n│     4 │     5 │     6 │\n╰───────┴───────┴───────╯\n'
 
 
 def test_table():
     """Tests the table function"""
     output = StringIO()
     table([[1, 2, 3], [4, 5, 6]], 'ABC', style='round', width=5, out=output)
-    assert output.getvalue() == '╭─────┬─────┬─────╮\n│  A  │  B  │  C  │\n├─────┼─────┼─────┤\n│    1│    2│    3│\n│    4│    5│    6│\n╰─────┴─────┴─────╯\n'
+    assert output.getvalue() == '╭───────┬───────┬───────╮\n│   A   │   B   │   C   │\n├───────┼───────┼───────┤\n│     1 │     2 │     3 │\n│     4 │     5 │     6 │\n╰───────┴───────┴───────╯\n'
 
     output = StringIO()
     table(["bar"], "foo", style='grid', width=3, out=output)


### PR DESCRIPTION
I think that with padding table looks better

Without padding:
![table without padding](https://monosnap.com/file/sREaIQXOcvtCoo660mLwrpOfjajI6a.png)

With padding:
![table with padding](https://monosnap.com/file/2Pfn2lwOoaHIkrdCYRPwVfuSexEeS2.png)