### PR TITLE
Removes numpy dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
   - conda update -q conda
   # Useful for debugging any issues with conda
   - conda info -a
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION pip numpy
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION pip numpy pandas
   - source activate test-environment
   - travis_retry pip install -r requirements-dev.txt
   - travis_retry python setup.py install

--- a/README.md
+++ b/README.md
@@ -57,13 +57,13 @@ Hosted at Read The Docs: [tableprint.readthedocs.org](http://tableprint.readthed
 
 ## 📦 Dependencies
 - Python 3.6, 3.5, 3.4, or 2.7
-- `numpy`
-- `six`
+- [future](https://pypi.org/project/future/)
+- [six](https://pypi.org/project/six/)
 
 ## 🛠 Changelog
 | Version | Release Date | Description |
 |    ---: |      :---:   | :---        |
-| 0.8.0 | Oct 24 2017 | Improves support for international languages
+| 0.8.0 | Oct 24 2017 | Improves support for international languages, removes numpy dependency
 | 0.7.0 | May 26 2017 | Adds a TableContext context manager for easy creation of dynamic tables (tables that update periodically). Adds the ability to pass a list or tuple of widths to specify different widths for different columns
 | 0.6.9 | May 25 2017 | Splitting the tableprint.py module into a pacakge with multiple files
 | 0.6.7 | May 25 2017 | Fixes some bugs with ANSI escape sequences

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 -r requirements.txt
+pandas
 pytest
 coverage

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-numpy
 six
 future

--- a/setup.py
+++ b/setup.py
@@ -57,13 +57,13 @@ setup(
     # project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['numpy', 'six', 'future', 'wcwidth'],
+    install_requires=['six', 'future', 'wcwidth'],
 
     # List additional groups of dependencies here (e.g. development dependencies).
     # You can install these using the following syntax, for example:
     # $ pip install -e .[dev,test]
     extras_require={
         'dev': [],
-        'test': ['pytest', 'coverage'],
+        'test': ['pandas', 'pytest', 'coverage'],
     },
 )

--- a/tableprint/metadata.py
+++ b/tableprint/metadata.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # Version info
-__version__ = '0.7.1'
+__version__ = '0.8.0'
 __license__ = 'MIT'
 
 # Project description(s)

--- a/tableprint/printer.py
+++ b/tableprint/printer.py
@@ -15,7 +15,6 @@ from __future__ import print_function, unicode_literals
 import sys
 from numbers import Number
 
-import numpy as np
 from six import string_types
 
 from .style import LineStyle, STYLES
@@ -268,4 +267,4 @@ def dataframe(df, **kwargs):
     df : DataFrame
         A pandas DataFrame with the table to print
     """
-    table(np.array(df), list(df.columns), **kwargs)
+    table(df.values, list(df.columns), **kwargs)

--- a/tableprint/utils.py
+++ b/tableprint/utils.py
@@ -4,8 +4,8 @@ Tableprint utilities
 """
 from __future__ import print_function, unicode_literals
 from wcwidth import wcswidth
+import math
 import re
-import numpy as np
 
 __all__ = ('humantime',)
 
@@ -30,22 +30,22 @@ def humantime(time):
 
     # weeks
     if time >= 7 * 60 * 60 * 24:
-        weeks = np.floor(time / (7 * 60 * 60 * 24))
+        weeks = math.floor(time / (7 * 60 * 60 * 24))
         timestr = "{:g} weeks, ".format(weeks) + humantime(time % (7 * 60 * 60 * 24))
 
     # days
     elif time >= 60 * 60 * 24:
-        days = np.floor(time / (60 * 60 * 24))
+        days = math.floor(time / (60 * 60 * 24))
         timestr = "{:g} days, ".format(days) + humantime(time % (60 * 60 * 24))
 
     # hours
     elif time >= 60 * 60:
-        hours = np.floor(time / (60 * 60))
+        hours = math.floor(time / (60 * 60))
         timestr = "{:g} hours, ".format(hours) + humantime(time % (60 * 60))
 
     # minutes
     elif time >= 60:
-        minutes = np.floor(time / 60.)
+        minutes = math.floor(time / 60.)
         timestr = "{:g} min., ".format(minutes) + humantime(time % 60)
 
     # seconds

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 from tableprint import table, banner, dataframe, hrule, TableContext
 from io import StringIO
-import numpy as np
+import pandas as pd
 
 
 def test_context():
@@ -27,17 +27,7 @@ def test_table():
 
 def test_frame():
     """Tests the dataframe function"""
-    # mock of a pandas DataFrame
-    class DataFrame:
-        def __init__(self, data, headers):
-            self.data = data
-            self.columns = headers
-
-        def __array__(self):
-            return self.data
-
-    # build a mock DataFrame
-    df = DataFrame(np.array([[1, 2, 3]]), ['a', 'b', 'c'])
+    df = pd.DataFrame({'a': [1,], 'b': [2,], 'c': [3,]})
     output = StringIO()
     dataframe(df, width=4, style='fancy_grid', out=output)
     assert output.getvalue() == '╒════╤════╤════╕\n│ a  │ b  │ c  │\n╞════╪════╪════╡\n│   1│   2│   3│\n╘════╧════╧════╛\n'


### PR DESCRIPTION
As pointed out in issue #8, requiring numpy as a dependency is unnecessary for such a lightweight utility.

This PR replaces the two places where numpy was used:
- Switches from `np.floor` to `math.floor` when rounding, and
- Converts a pandas DataFrame to a numpy array using a class method (as opposed to a numpy function)