### PR TITLE
Adhere to PEP8

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # tableprint
+
 Pretty console printing :clipboard: of tabular data in python :snake:
 
 [![Build Status](https://travis-ci.org/nirum/tableprint.svg?branch=master)](https://travis-ci.org/nirum/tableprint)
@@ -7,6 +8,7 @@ Pretty console printing :clipboard: of tabular data in python :snake:
 [![PyPi version](https://img.shields.io/pypi/v/tableprint.svg)](https://pypi.python.org/pypi/tableprint)
 
 ## ℹ︎ About
+
 `tableprint` lets you easily print formatted tables of data.
 Unlike other modules, you can print single rows of data at a time (useful for printing ongoing computation results).
 
@@ -14,22 +16,25 @@ Unlike other modules, you can print single rows of data at a time (useful for pr
 
 ## 🔎 Table of Contents
 
-  * [About](#ℹ%EF%B8%8E-about)
-  * [Installation](#-installation)
-  * [Usage](#-usage)
-  * [Documentation](#-documentation)
-  * [Dependencies](#-dependencies)
-  * [Contributors](#heart-contributors)
-  * [Changelog](#-changelog)
-  * [License](#-license)
+-   [About](#ℹ%EF%B8%8E-about)
+-   [Installation](#-installation)
+-   [Usage](#-usage)
+-   [Documentation](#-documentation)
+-   [Dependencies](#-dependencies)
+-   [Contributors](#heart-contributors)
+-   [Changelog](#-changelog)
+-   [License](#-license)
 
 ## 💻 Installation
+
 ```bash
 pip install tableprint
 ```
 
 ## 🏃 Usage
+
 The `table` function takes in a matrix of data, a list of headers, a width (defaults to 11) and a style (defaults to 'round'). To print a dataset consisting of 10 rows of 3 different columns with the default width and style:
+
 ```python
 import tableprint as tp
 import numpy as np
@@ -39,9 +44,11 @@ headers = ['Column A', 'Column B', 'Column C']
 
 tp.table(data, headers)
 ```
+
 The `header` and `row` functions allow you to print just the header or just a row of data, respectively, which is useful for continuously updating a table during a long-running computation. Also, the `banner` function is useful for just printing out a nicely formatted message to the user.
 
 The `TableContext` context manager is useful for dynamically updating tables (e.g. during a long running computation):
+
 ```python
 import tableprint as tp
 import numpy as np
@@ -54,32 +61,37 @@ with tp.TableContext("ABC") as t:
 ```
 
 ## 📚 Documentation
+
 Hosted at Read The Docs: [tableprint.readthedocs.org](http://tableprint.readthedocs.org)
 
 ## 📦 Dependencies
-- Python 3.5+ or 2.7
-- [future](https://pypi.org/project/future/)
-- [six](https://pypi.org/project/six/)
+
+-   Python 3.5+ or 2.7
+-   [future](https://pypi.org/project/future/)
+-   [six](https://pypi.org/project/six/)
 
 ## :heart: Contributors
-Thanks to: [@nowox](https://github.com/nowox), [@nicktimko](https://github.com/nicktimko), and [@mubaris](https://github.com/mubaris) for contributions.
+
+Thanks to: [@nowox](https://github.com/nowox), [@nicktimko](https://github.com/nicktimko), [@mubaris](https://github.com/mubaris), and [@sumanthratna](https://github.com/sumanthratna) for contributions.
 
 ## 🛠 Changelog
-| Version | Release Date | Description |
-|    ---: |      :---:   | :---        |
-| 0.9.0 | May 16 2020 | Adds support for automatically determining the table's width.
-| 0.8.0 | Oct 24 2017 | Improves support for international languages, removes numpy dependency
-| 0.7.0 | May 26 2017 | Adds a TableContext context manager for easy creation of dynamic tables (tables that update periodically). Adds the ability to pass a list or tuple of widths to specify different widths for different columns
-| 0.6.9 | May 25 2017 | Splitting the tableprint.py module into a pacakge with multiple files
-| 0.6.7 | May 25 2017 | Fixes some bugs with ANSI escape sequences
-| 0.5.0 | Sept 29 2016 | Better handling of ANSI escape sequences in table rows
-| 0.4.0 | May 3 2016 | Adds a 'block' style
-| 0.3.2 | May 3 2016 | Adds a test suite
-| 0.3.0 | May 3 2016 | Adds custom styles for tables, specified by a key ('fancy_grid', 'grid', etc.)
-| 0.2.0 | May 2 2016 | Adds better python2 (unicode/bytes) compatibility
-| 0.1.5 | Oct 1 2015 | Renamed hrtime to humantime, added docs
-| 0.1.4 | Sept 28 2015 | Added human readable string converter (hrtime)
-| 0.1.0 | Feb 24 2015 | Initial release
+
+| Version | Release Date | Description                                                                                                                                                                                                     |
+| ------: | :----------: | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|   0.9.0 |  May 16 2020 | Adds support for automatically determining the table's width.                                                                                                                                                   |
+|   0.8.0 |  Oct 24 2017 | Improves support for international languages, removes numpy dependency                                                                                                                                          |
+|   0.7.0 |  May 26 2017 | Adds a TableContext context manager for easy creation of dynamic tables (tables that update periodically). Adds the ability to pass a list or tuple of widths to specify different widths for different columns |
+|   0.6.9 |  May 25 2017 | Splitting the tableprint.py module into a pacakge with multiple files                                                                                                                                           |
+|   0.6.7 |  May 25 2017 | Fixes some bugs with ANSI escape sequences                                                                                                                                                                      |
+|   0.5.0 | Sept 29 2016 | Better handling of ANSI escape sequences in table rows                                                                                                                                                          |
+|   0.4.0 |  May 3 2016  | Adds a 'block' style                                                                                                                                                                                            |
+|   0.3.2 |  May 3 2016  | Adds a test suite                                                                                                                                                                                               |
+|   0.3.0 |  May 3 2016  | Adds custom styles for tables, specified by a key ('fancy_grid', 'grid', etc.)                                                                                                                                  |
+|   0.2.0 |  May 2 2016  | Adds better python2 (unicode/bytes) compatibility                                                                                                                                                               |
+|   0.1.5 |  Oct 1 2015  | Renamed hrtime to humantime, added docs                                                                                                                                                                         |
+|   0.1.4 | Sept 28 2015 | Added human readable string converter (hrtime)                                                                                                                                                                  |
+|   0.1.0 |  Feb 24 2015 | Initial release                                                                                                                                                                                                 |
 
 ## 🔓 License
-MIT. See `LICENSE.md`
+
+MIT. See [`LICENSE.md`](./LICENSE.md)

--- a/tableprint/printer.py
+++ b/tableprint/printer.py
@@ -21,7 +21,8 @@ from six import string_types
 from .style import LineStyle, STYLES
 from .utils import ansi_len, format_line, parse_width, max_width
 
-__all__ = ('table', 'header', 'row', 'hrule', 'top', 'bottom', 'banner', 'dataframe', 'TableContext')
+__all__ = ('table', 'header', 'row', 'hrule', 'top',
+           'bottom', 'banner', 'dataframe', 'TableContext')
 
 # Defaults
 STYLE = 'round'
@@ -31,19 +32,29 @@ ALIGNMENTS = {"left": "<", "right": ">", "center": "^"}
 
 
 class TableContext:
-    def __init__(self, headers, width=11, align=ALIGN, style=STYLE, add_hr=True, out=sys.stdout):
+    def __init__(
+        self,
+        headers,
+        width=11,
+        align=ALIGN,
+        style=STYLE,
+        add_hr=True,
+        out=sys.stdout
+    ):
         """Context manager for table printing
 
         Parameters
         ----------
         headers: array_like
-            A list of N strings consisting of the header of each of the N columns
+            A list of N strings consisting of the header of each of the N
+            columns.
 
         width: int or array_like, optional
             The width of each column in the table (Default: 11)
 
-        align: str
-            The alignment to use ('left', 'center', or 'right'). (Default: 'right')
+        align: str, optional
+            The alignment to use ('left', 'center', or 'right'). (Default:
+            'right')
 
         style: str or tuple, optional
             A formatting style. (Default: 'round')
@@ -52,9 +63,9 @@ class TableContext:
             Whether or not to add a horizontal rule (hr) after the headers
 
         out: IO writer, optional
-            Object used to manage IO (displaying the table). Must have a write() method
-            that takes a string argument, and a flush() method. See sys.stdout for an
-            example. (Default: 'sys.stdout')
+            Object used to manage IO (displaying the table). Must have a
+            write() method that takes a string argument, and a flush() method.
+            See sys.stdout for an example. (Default: 'sys.stdout')
 
         Usage
         -----
@@ -81,7 +92,15 @@ class TableContext:
         self.out.flush()
 
 
-def table(data, headers=None, format_spec=FMT, width=None, align=ALIGN, style=STYLE, out=sys.stdout):
+def table(
+    data,
+    headers=None,
+    format_spec=FMT,
+    width=None,
+    align=ALIGN,
+    style=STYLE,
+    out=sys.stdout
+):
     """Print a table with the given data
 
     Parameters
@@ -90,31 +109,33 @@ def table(data, headers=None, format_spec=FMT, width=None, align=ALIGN, style=ST
         An (m x n) array containing the data to print (m rows of n columns)
 
     headers: list, optional
-        A list of n strings consisting of the header of each of the n columns (Default: None)
+        A list of n strings consisting of the header of each of the n columns
+        (Default: None)
 
     format_spec: string, optional
         Format specification for formatting numbers (Default: '5g')
 
     width: int or None or array_like, optional
-        The width of each column in the table. If None, tries to estimate an appropriate width
-        based on the length of the data in the table. (Default: None)
+        The width of each column in the table. If None, tries to estimate an
+        appropriate width based on the length of the data in the table.
+        (Default: None)
 
-    align: string
+    align: string, optional
         The alignment to use ('left', 'center', or 'right'). (Default: 'right')
 
     style: string or tuple, optional
         A formatting style. (Default: 'fancy_grid')
 
     out: IO writer, optional
-        File handle or object used to manage IO (displaying the table). Must have a write()
-        method that takes a string argument, and a flush() method. See sys.stdout for an
-        example. (Default: 'sys.stdout')
+        File handle or object used to manage IO (displaying the table). Must
+        have a write() method that takes a string argument, and a flush()
+        method. See sys.stdout for an example. (Default: 'sys.stdout')
     """
     # Auto-width.
     if width is None:
-      max_header_width = 0 if headers is None else max_width(headers, FMT)
-      max_data_width = max_width(chain(*data), format_spec)
-      width = max(max_header_width, max_data_width)
+        max_header_width = 0 if headers is None else max_width(headers, FMT)
+        max_data_width = max_width(chain(*data), format_spec)
+        width = max(max_header_width, max_data_width)
 
     # Number of columns in the table.
     ncols = len(data[0]) if headers is None else len(headers)
@@ -122,8 +143,8 @@ def table(data, headers=None, format_spec=FMT, width=None, align=ALIGN, style=ST
     widths = parse_width(width, ncols)
 
     # Initialize with a hr or the header
-    tablestr = [hrule(ncols, widths, tablestyle.top)] \
-        if headers is None else [header(headers, width=widths, align=align, style=style)]
+    tablestr = [hrule(ncols, widths, tablestyle.top)] if headers is None \
+        else [header(headers, width=widths, align=align, style=style)]
 
     # parse each row
     tablestr += [row(d, widths, format_spec, align, style) for d in data]
@@ -145,8 +166,9 @@ def header(headers, width=None, align=ALIGN, style=STYLE, add_hr=True):
     headers: list of strings
         A list of n strings, the column headers
 
-    width: int
-        The width of each column. If None, automatically determines the width. (Default: None)
+    width: int, optional
+        The width of each column. If None, automatically determines the width.
+        (Default: None)
 
     style: string or tuple, optional
         A formatting style (see STYLES)
@@ -157,14 +179,15 @@ def header(headers, width=None, align=ALIGN, style=STYLE, add_hr=True):
         A string consisting of the full header row to print
     """
     if width is None:
-      width = max_width(headers, FMT)
+        width = max_width(headers, FMT)
 
     tablestyle = STYLES[style]
     widths = parse_width(width, len(headers))
     alignment = ALIGNMENTS[align]
 
     # string formatter
-    data = map(lambda x: ('{:%s%d}' % (alignment, x[0] + ansi_len(x[1]))).format(x[1]), zip(widths, headers))
+    data = map(lambda x: ('{:%s%d}' % (
+        alignment, x[0] + ansi_len(x[1]))).format(x[1]), zip(widths, headers))
 
     # build the formatted str
     headerstr = format_line(data, tablestyle.row)
@@ -183,15 +206,18 @@ def row(values, width=None, format_spec=FMT, align=ALIGN, style=STYLE):
     Parameters
     ----------
     values: array_like
-        An iterable array of data (numbers or strings), each value is printed in a separate column
+        An iterable array of data (numbers or strings), each value is printed
+        in a separate column
 
-    width: int
-        The width of each column. If None, automatically determines the width. (Default: None)
+    width: int, optional
+        The width of each column. If None, automatically determines the width.
+        (Default: None)
 
-    format_spec: string
-        The precision format string used to format numbers in the values array (Default: '5g')
+    format_spec: string, optional
+        The precision format string used to format numbers in the values array
+        (Default: '5g')
 
-    align: string
+    align: string, optional
         The alignment to use ('left', 'center', or 'right'). (Default: 'right')
 
     style: namedtuple, optional
@@ -203,12 +229,14 @@ def row(values, width=None, format_spec=FMT, align=ALIGN, style=STYLE):
         A string consisting of the full row of data to print
     """
     if width is None:
-      width = max_width(values, format_spec)
+        width = max_width(values, format_spec)
 
     tablestyle = STYLES[style]
     widths = parse_width(width, len(values))
 
-    assert isinstance(format_spec, string_types) | isinstance(format_spec, list), \
+    format_spec_is_valid_type = isinstance(format_spec, string_types) or \
+        isinstance(format_spec, list)
+    assert format_spec_is_valid_type, \
         "format_spec must be a string or list of strings"
 
     if isinstance(format_spec, string_types):
@@ -218,11 +246,18 @@ def row(values, width=None, format_spec=FMT, align=ALIGN, style=STYLE):
     def mapdata(width, datum, prec):
         """Formats an individual piece of data."""
         if isinstance(datum, string_types):
-            return ('{:%s%i}' % (ALIGNMENTS[align], width + ansi_len(datum))).format(datum)
+            return (
+                '{:%s%i}' % (ALIGNMENTS[align], width + ansi_len(datum))
+            ).format(datum)
         elif isinstance(datum, Number):
-            return ('{:%s%i.%s}' % (ALIGNMENTS[align], width, prec)).format(datum)
+            return (
+                '{:%s%i.%s}' % (ALIGNMENTS[align], width, prec)
+            ).format(datum)
         else:
-            raise ValueError('Elements in the values array must be strings, ints, or floats')
+            raise ValueError(
+                'Elements in the values array must be '
+                'strings, ints, or floats'
+            )
 
     # string formatter
     data = starmap(mapdata, zip(widths, values, format_spec))
@@ -236,15 +271,15 @@ def hrule(n=1, width=11, linestyle=LineStyle('', '─', '─', '')):
 
     Parameters
     ----------
-    n: int
+    n: int, optional
         The number of columns in the table
 
-    width: int
+    width: int, optional
         The width of each column (Default: 11)
 
-    linestyle: tuple
-        A LineStyle namedtuple containing the characters for (begin, hr, sep, end).
-        (Default: ('', '─', '─', ''))
+    linestyle: tuple, optional
+        A LineStyle namedtuple containing the characters for (begin, hr, sep,
+        end). (Default: ('', '─', '─', ''))
 
     Returns
     -------
@@ -252,8 +287,9 @@ def hrule(n=1, width=11, linestyle=LineStyle('', '─', '─', '')):
         A string consisting of the row border to print
     """
     widths = parse_width(width, n)
-    hrstr = linestyle.sep.join([('{:%s^%i}' % (linestyle.hline, width)).format('')
-                                for width in widths])
+    hrstr = linestyle.sep.join(
+        [('{:%s^%i}' % (linestyle.hline, width)).format('')for width in widths]
+    )
     return linestyle.begin + hrstr + linestyle.end
 
 
@@ -284,7 +320,8 @@ def banner(message, width=30, style='banner', out=sys.stdout):
     out: writer
         An object that has write() and flush() methods (Default: sys.stdout)
     """
-    out.write(header([message], width=max(width, len(message)), style=style) + '\n')
+    out.write(header([message], width=max(
+        width, len(message)), style=style) + '\n')
     out.flush()
 
 

--- a/tableprint/utils.py
+++ b/tableprint/utils.py
@@ -35,7 +35,8 @@ def humantime(time):
     # weeks
     if time >= 7 * 60 * 60 * 24:
         weeks = math.floor(time / (7 * 60 * 60 * 24))
-        timestr = "{:g} weeks, ".format(weeks) + humantime(time % (7 * 60 * 60 * 24))
+        timestr = "{:g} weeks, ".format(
+            weeks) + humantime(time % (7 * 60 * 60 * 24))
 
     # days
     elif time >= 60 * 60 * 24:
@@ -105,10 +106,13 @@ def max_width(data, format_spec):
     def compute_width(d):
         """Computes the formatted width of single element."""
         if isinstance(d, string_types):
-          return len(d)
+            return len(d)
         if isinstance(d, Number):
-          return len(('{:0.%s}' % format_spec).format(d))
+            return len(('{:0.%s}' % format_spec).format(d))
         else:
-            raise ValueError('Elements in the values array must be strings, ints, or floats')
+            raise ValueError(
+                'Elements in the values array must be '
+                'strings, ints, or floats'
+            )
 
     return reduce(max, map(compute_width, data))

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -11,26 +11,26 @@ def test_context():
     with TableContext('ABC', style='round', width=5, out=output) as t:
         t([1, 2, 3])
         t([4, 5, 6])
-    assert output.getvalue() == '╭───────┬───────┬───────╮\n│     A │     B │     C │\n├───────┼───────┼───────┤\n│     1 │     2 │     3 │\n│     4 │     5 │     6 │\n╰───────┴───────┴───────╯\n'
+    assert output.getvalue() == '╭───────┬───────┬───────╮\n│     A │     B │     C │\n├───────┼───────┼───────┤\n│     1 │     2 │     3 │\n│     4 │     5 │     6 │\n╰───────┴───────┴───────╯\n'  # noqa
 
 
 def test_table():
     """Tests the table function"""
     output = StringIO()
     table([[1, 2, 3], [4, 5, 6]], 'ABC', style='round', width=5, out=output)
-    assert output.getvalue() == '╭───────┬───────┬───────╮\n│     A │     B │     C │\n├───────┼───────┼───────┤\n│     1 │     2 │     3 │\n│     4 │     5 │     6 │\n╰───────┴───────┴───────╯\n'
+    assert output.getvalue() == '╭───────┬───────┬───────╮\n│     A │     B │     C │\n├───────┼───────┼───────┤\n│     1 │     2 │     3 │\n│     4 │     5 │     6 │\n╰───────┴───────┴───────╯\n'  # noqa
 
     output = StringIO()
     table(["bar"], "foo", style='grid', width=3, out=output)
-    assert output.getvalue() == '+---+---+---+\n|  f|  o|  o|\n+---+---+---+\n|  b|  a|  r|\n+---+---+---+\n'
+    assert output.getvalue() == '+---+---+---+\n|  f|  o|  o|\n+---+---+---+\n|  b|  a|  r|\n+---+---+---+\n'  # noqa
 
 
 def test_frame():
     """Tests the dataframe function"""
-    df = pd.DataFrame({'a': [1,], 'b': [2,], 'c': [3,]})
+    df = pd.DataFrame({'a': [1, ], 'b': [2, ], 'c': [3, ]})
     output = StringIO()
     dataframe(df, width=4, style='fancy_grid', out=output)
-    assert output.getvalue() == '╒════╤════╤════╕\n│   a│   b│   c│\n╞════╪════╪════╡\n│   1│   2│   3│\n╘════╧════╧════╛\n'
+    assert output.getvalue() == '╒════╤════╤════╕\n│   a│   b│   c│\n╞════╪════╪════╡\n│   1│   2│   3│\n╘════╧════╧════╛\n'  # noqa
 
 
 def test_banner():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -23,13 +23,15 @@ def test_format_line():
     """Tests line formatting"""
 
     # using ASCII
-    assert format_line(['foo', 'bar'], LineStyle('(', '_', '+', ')')) == '(foo+bar)'
+    assert format_line(['foo', 'bar'], LineStyle(
+        '(', '_', '+', ')')) == '(foo+bar)'
     assert format_line("abc", LineStyle('[', '*', '.', ']')) == '[a.b.c]'
     assert format_line(["_"], LineStyle('o', '', '!', 'o')) == 'o_o'
     assert format_line([], LineStyle(':', '', '', ')')) == ':)'
 
     # using unicode
-    assert format_line(['.', '.', '.'], LineStyle('★', '_', '╳', '☆')) == '★.╳.╳.☆'
+    assert format_line(['.', '.', '.'], LineStyle('★', '_', '╳', '☆')) == \
+        '★.╳.╳.☆'
     assert format_line("☚☛", LineStyle('♪', '*', '♩', '♫')) == '♪☚♩☛♫'
 
 


### PR DESCRIPTION
This commit: 
- reduces the number of autopep8 warnings
- adds `optional` to appropriate named arguments in docstrings
- formats README with Tidy Markdown

Nothing serious, just formatting changes. Feel free to close this if you don't want these changes. 