### PR TITLE
Remove future from install_requires

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,7 @@ Hosted at Read The Docs: [tableprint.readthedocs.org](http://tableprint.readthed
 ## 📦 Dependencies
 
 -   Python 3.6+
--   [future](https://pypi.org/project/future/)
--   [six](https://pypi.org/project/six/)
+-   [wcwidth](https://pypi.org/project/wcwidth/)
 
 ## :heart: Contributors
 

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
     # project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['future', 'wcwidth'],
+    install_requires=['wcwidth'],
 
     # List additional groups of dependencies here (e.g. development dependencies).
     # You can install these using the following syntax, for example:


### PR DESCRIPTION
The future module is not used, so remove it from install_requires. I've also cleaned up the readme, dropping it and six.